### PR TITLE
Fix issues on MacOS (#6), bumped version to 0.2.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,14 @@ if not os.path.exists("timelib.c"):
     os.system("cython timelib.pyx")
 
 setup(name="timelib",
-      version="0.2.4",
+      version="0.2.5",
       description="parse english textual date descriptions",
       author="Ralf Schmitt",
       author_email="ralf@systemexit.de",
       url="https://github.com/pediapress/timelib/",
       ext_modules=[Extension("timelib", sources=sources,
                              libraries=libraries,
+                             include_dirs=[".", "ext-date-lib"],
                              define_macros=[("HAVE_STRING_H", 1)])],
       include_dirs=[".", "ext-date-lib"],
       long_description=open("README.rst").read(),


### PR DESCRIPTION
I was having the same issue as others reported, and with this change (suggested in #6) works fine, so I've decided to move forward and create a PR.

FTR: I was not being able to install salt-ssh on my machine because of this issue (https://github.com/saltstack/salt/issues/56108)